### PR TITLE
Debug parameter removed from StreamListener

### DIFF
--- a/betfairutil/__init__.py
+++ b/betfairutil/__init__.py
@@ -792,7 +792,7 @@ def read_prices_file(
     stream = trading.streaming.create_historical_generator_stream(
         file_path=path_to_prices_file,
         listener=StreamListener(
-            max_latency=None, lightweight=lightweight, debug=False, update_clk=False
+            max_latency=None, lightweight=lightweight, update_clk=False
         ),
     )
 


### PR DESCRIPTION
The debug parameter was deprecated and then removed from betfairlightweight, causing an error when the read_prices_file is streamed with the latest versions of BFLW.

Ref: https://github.com/liampauling/betfair/commit/b081a51b1d3afb734f370eaa6b4878f40f2cacbb